### PR TITLE
Show rain mm in weather popup

### DIFF
--- a/src/app/components/current-weather-card/current-weather-card.module.css
+++ b/src/app/components/current-weather-card/current-weather-card.module.css
@@ -33,6 +33,7 @@
   color: var(--dark-purple);
   font-weight: 600;
   width: fit-content;
+  white-space: nowrap;
   opacity: 0;
 }
 

--- a/src/app/components/current-weather-card/index.tsx
+++ b/src/app/components/current-weather-card/index.tsx
@@ -10,6 +10,7 @@ export default function CurrentWeatherCard(props: {
 }) {
   const { currentWeather } = props;
   const { icon, description, main } = currentWeather.weather[0];
+  const rain = currentWeather.rain?.["1h"];
 
   return (
     <div
@@ -20,7 +21,7 @@ export default function CurrentWeatherCard(props: {
       <div className={styles.icon}>
         <WeatherIcon icon={icon} />
         <div className={styles.popup} role="dialog">
-          {description}
+          {description}{rain ? ` · ${rain.toFixed(1)} mm` : ""}
         </div>
       </div>
       <Temperature temperature={currentWeather.main.temp} />

--- a/src/app/components/current-weather-card/index.tsx
+++ b/src/app/components/current-weather-card/index.tsx
@@ -21,7 +21,7 @@ export default function CurrentWeatherCard(props: {
       <div className={styles.icon}>
         <WeatherIcon icon={icon} />
         <div className={styles.popup} role="dialog">
-          {description}{rain ? ` · ${rain.toFixed(1)} mm` : ""}
+          {description}{rain ? <span style={{ textTransform: "none" }}>{` · ${rain.toFixed(1)} mm`}</span> : ""}
         </div>
       </div>
       <Temperature temperature={currentWeather.main.temp} />

--- a/src/app/components/forecast-card/forecast.module.css
+++ b/src/app/components/forecast-card/forecast.module.css
@@ -42,6 +42,7 @@
   color: var(--dark-purple);
   font-weight: 600;
   width: fit-content;
+  white-space: nowrap;
   opacity: 0;
   text-transform: capitalize;
 }

--- a/src/app/components/forecast-card/index.tsx
+++ b/src/app/components/forecast-card/index.tsx
@@ -7,7 +7,7 @@ import Wind from "@/app/ui/wind";
 
 export default function ForecastCard(props: { forecast: Forecast }) {
   const { forecast } = props;
-  const { dt_txt, description, temp, icon, wind } = forecast;
+  const { dt_txt, description, temp, icon, wind, rain } = forecast;
   const time = dt_txt.toLocaleString().split(",")[1];
   const meridium = time.substring(time.length - 3, time.length);
   const formattedTime = time.substring(0, time.length - 6) + meridium;
@@ -23,7 +23,7 @@ export default function ForecastCard(props: { forecast: Forecast }) {
 
       <div className={styles.description}>
         <div className={styles.popup} role="dialog">
-          {description}
+          {description}{rain ? ` · ${rain.toFixed(1)} mm` : ""}
         </div>
         <WeatherIcon icon={icon} />
       </div>

--- a/src/app/components/forecast-card/index.tsx
+++ b/src/app/components/forecast-card/index.tsx
@@ -23,7 +23,7 @@ export default function ForecastCard(props: { forecast: Forecast }) {
 
       <div className={styles.description}>
         <div className={styles.popup} role="dialog">
-          {description}{rain ? ` · ${rain.toFixed(1)} mm` : ""}
+          {description}{rain ? <span style={{ textTransform: "none" }}>{` · ${rain.toFixed(1)} mm`}</span> : ""}
         </div>
         <WeatherIcon icon={icon} />
       </div>

--- a/src/app/model/index.ts
+++ b/src/app/model/index.ts
@@ -18,6 +18,7 @@ export const weatherForecastSchema = z.array(
     wind: z.object({
       speed: z.number(),
     }),
+    rain: z.object({ "3h": z.number() }).optional(),
   })
 );
 
@@ -36,6 +37,7 @@ export const currentWeatherSchema = z.object({
   wind: z.object({
     speed: z.number(),
   }),
+  rain: z.object({ "1h": z.number() }).optional(),
 });
 
 export type Forecast = {
@@ -45,6 +47,7 @@ export type Forecast = {
   wind: number;
   description: string;
   main: string;
+  rain?: number;
 };
 
 export type Hours = number;

--- a/src/app/utils/reduce-day-forecasts.ts
+++ b/src/app/utils/reduce-day-forecasts.ts
@@ -17,6 +17,7 @@ export default function reduceDayForecasts(
       wind: current.wind.speed,
       description: current.weather[0].description,
       main: current.weather[0].main,
+      rain: current.rain?.["3h"],
     });
 
     return acc;


### PR DESCRIPTION
## Summary
- Adds `rain` field to the `WeatherForecast` and `CurrentWeather` Zod schemas (optional, as the API only includes it when rain is occurring)
- Threads rain data through `reduceDayForecasts` into the `Forecast` type
- Appends rain volume to the existing description popup on hover (e.g. `heavy rain · 2.3 mm`), keeping the card layout unchanged

## Test plan
- [ ] Hover the weather icon on a forecast card with rain — popup shows description + mm value
- [ ] Hover the weather icon on a clear-sky card — popup shows description only (no `· 0.0 mm`)
- [ ] Check current weather card popup behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)