### PR TITLE
Only show precipitation probability for rain/snow/storm forecasts

### DIFF
--- a/src/app/components/forecast-card/index.tsx
+++ b/src/app/components/forecast-card/index.tsx
@@ -7,7 +7,8 @@ import Wind from "@/app/ui/wind";
 
 export default function ForecastCard(props: { forecast: Forecast }) {
   const { forecast } = props;
-  const { dt_txt, description, temp, icon, wind, rain, pop } = forecast;
+  const { dt_txt, description, temp, icon, wind, rain, pop, main } = forecast;
+  const isPrecip = ["Rain", "Drizzle", "Snow", "Thunderstorm"].includes(main);
   const time = dt_txt.toLocaleString().split(",")[1];
   const meridium = time.substring(time.length - 3, time.length);
   const formattedTime = time.substring(0, time.length - 6) + meridium;
@@ -24,10 +25,10 @@ export default function ForecastCard(props: { forecast: Forecast }) {
       <div className={styles.description}>
         <div className={styles.popup} role="dialog">
           {description}
-          {(pop || rain) ? (
+          {(isPrecip && pop) || rain ? (
             <span style={{ textTransform: "none", display: "block" }}>
-              {pop ? `${Math.round(pop * 100)}%` : ""}
-              {pop && rain ? " · " : ""}
+              {isPrecip && pop ? `${Math.round(pop * 100)}%` : ""}
+              {isPrecip && pop && rain ? " · " : ""}
               {rain ? `${rain.toFixed(1)} mm` : ""}
             </span>
           ) : ""}


### PR DESCRIPTION
## Summary
- `pop` (probability of precipitation) is now only shown in the popup when `main` is one of `Rain`, `Drizzle`, `Snow`, or `Thunderstorm`
- Fixes misleading percentages showing on clear/cloudy forecasts (e.g. "Scattered Clouds · 70%") caused by OpenWeatherMap bleeding `pop` values into non-precipitation time slots

## Test plan
- [ ] Hover a rainy forecast — popup shows description + `70% · 2.3mm` second line
- [ ] Hover a cloudy/clear forecast — popup shows description only, no percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)