### PR TITLE
Unify popup, add feels like & humidity, fix SP positioning

### DIFF
--- a/src/app/ui/popup/index.tsx
+++ b/src/app/ui/popup/index.tsx
@@ -7,15 +7,12 @@ type Props = {
 };
 
 export const Popup = ({ content, children, position = "right" }: Props) => {
-  const translate =
-    position === "left" ? "translateX(-35px)" : "translateX(35px)";
   return (
     <div className={styles.container}>
       <div className={styles.children}>{children}</div>
       <div
-        className={styles.popup}
+        className={`${styles.popup} ${position === "left" ? styles.left : styles.right}`}
         role="dialog"
-        style={{ transform: translate }}
       >
         {content}
       </div>

--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -16,8 +16,10 @@
   width: fit-content;
   white-space: nowrap;
   z-index: 10;
-  top: 0%;
-  left: 100%;
+  /* default: centered below the trigger */
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .container:hover .popup {
@@ -25,9 +27,18 @@
   pointer-events: auto;
 }
 
-@media (max-width: 300px) {
-  .container .popup {
-    left: 0%;
-    top: -100%;
+/* on larger screens, float to the side instead */
+@media (min-width: 600px) {
+  .container .popup.right {
+    top: 0%;
+    left: 100%;
+    transform: translateX(5px);
+  }
+
+  .container .popup.left {
+    top: 0%;
+    left: auto;
+    right: 100%;
+    transform: translateX(-5px);
   }
 }

--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -19,10 +19,8 @@
   left: 100%;
 }
 
-@media (min-width: 500px) {
-  .container:hover .popup {
-    opacity: 1;
-  }
+.container:hover .popup {
+  opacity: 1;
 }
 
 @media (max-width: 300px) {

--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -6,6 +6,7 @@
   background-color: whitesmoke;
   position: absolute;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.3s ease-in-out;
   box-shadow: rgba(0, 0, 0, 0.5) 0px 5px 7px;
   border-radius: 5px;
@@ -21,6 +22,7 @@
 
 .container:hover .popup {
   opacity: 1;
+  pointer-events: auto;
 }
 
 @media (max-width: 300px) {


### PR DESCRIPTION
## Summary
- **Unified popup**: all card popups now use the shared `ui/Popup` component — removed duplicated CSS from both card modules
- **Bug fix**: temperature tap no longer triggers the weather popup — each has its own independent hover/tap zone
- **Bug fix**: hidden popups no longer intercept taps on adjacent elements (`pointer-events: none` when hidden)
- **SP positioning fix**: popup now appears centered below the trigger on mobile instead of flying off to the right; on desktop (≥600px) it floats to the side as before
- **Feels like + humidity**: hovering/tapping temperature shows a popup with `Feels like X°C` / `Humidity X%`

## Test plan
- [ ] SP: tap weather icon → popup opens centered below it
- [ ] SP: tap temperature → popup opens centered below it with feels like + humidity
- [ ] SP: tapping wind does not open any popup
- [ ] Desktop: popups appear to the right side as before
- [ ] Verify header button popups (geolocation, map) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)