### PR TITLE
Add wind gust and direction popup

### DIFF
--- a/src/app/components/current-weather-card/index.tsx
+++ b/src/app/components/current-weather-card/index.tsx
@@ -36,7 +36,7 @@ export default function CurrentWeatherCard(props: {
         feelsLike={currentWeather.main.feels_like}
         humidity={currentWeather.main.humidity}
       />
-      <Wind wind={currentWeather.wind.speed} />
+      <Wind wind={currentWeather.wind.speed} gust={currentWeather.wind.gust} deg={currentWeather.wind.deg} />
     </div>
   );
 }

--- a/src/app/components/forecast-card/index.tsx
+++ b/src/app/components/forecast-card/index.tsx
@@ -8,7 +8,7 @@ import { Popup } from "@/app/ui/popup";
 
 export default function ForecastCard(props: { forecast: Forecast }) {
   const { forecast } = props;
-  const { dt_txt, description, temp, icon, wind, rain, pop, main, feelsLike, humidity } = forecast;
+  const { dt_txt, description, temp, icon, wind, windGust, windDeg, rain, pop, main, feelsLike, humidity } = forecast;
   const isPrecip = ["Rain", "Drizzle", "Snow", "Thunderstorm"].includes(main);
   const time = dt_txt.toLocaleString().split(",")[1];
   const meridium = time.substring(time.length - 3, time.length);
@@ -41,7 +41,7 @@ export default function ForecastCard(props: { forecast: Forecast }) {
       </Popup>
 
       <Temperature temperature={temp} feelsLike={feelsLike} humidity={humidity} />
-      <Wind wind={wind} />
+      <Wind wind={wind} gust={windGust} deg={windDeg} />
     </div>
   );
 }

--- a/src/app/model/index.ts
+++ b/src/app/model/index.ts
@@ -19,6 +19,8 @@ export const weatherForecastSchema = z.array(
     ),
     wind: z.object({
       speed: z.number(),
+      gust: z.number().optional(),
+      deg: z.number().optional(),
     }),
     rain: z.object({ "3h": z.number() }).optional(),
     pop: z.number().optional(),
@@ -41,6 +43,8 @@ export const currentWeatherSchema = z.object({
   }),
   wind: z.object({
     speed: z.number(),
+    gust: z.number().optional(),
+    deg: z.number().optional(),
   }),
   rain: z.object({ "1h": z.number() }).optional(),
 });
@@ -50,6 +54,8 @@ export type Forecast = {
   temp: number;
   icon: string;
   wind: number;
+  windGust?: number;
+  windDeg?: number;
   description: string;
   main: string;
   rain?: number;

--- a/src/app/ui/wind.tsx
+++ b/src/app/ui/wind.tsx
@@ -1,12 +1,31 @@
-export default function Wind(props: { wind: number }) {
-  const wind = Math.floor(props.wind * 3.6);
+import { Popup } from "./popup";
+
+type Props = {
+  wind: number;
+  gust?: number;
+  deg?: number;
+};
+
+const DEG_TO_COMPASS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+
+function toCompass(deg: number) {
+  return DEG_TO_COMPASS[Math.round(deg / 45) % 8];
+}
+
+export default function Wind({ wind, gust, deg }: Props) {
+  const kmh = Math.floor(wind * 3.6);
+  const gustKmh = gust ? Math.floor(gust * 3.6) : undefined;
+
+  const content = (
+    <span>
+      {gustKmh && <span style={{ display: "block" }}>Gust {gustKmh} km/h</span>}
+      {deg !== undefined && <span style={{ display: "block" }}>From {toCompass(deg)}</span>}
+    </span>
+  );
+
   return (
-    <h5
-      style={{
-        transform: "translateY(5px)",
-      }}
-    >
-      ༄ {wind} Km/h
-    </h5>
+    <Popup content={content}>
+      <h5 style={{ transform: "translateY(5px)" }}>༄ {kmh} km/h</h5>
+    </Popup>
   );
 }

--- a/src/app/utils/reduce-day-forecasts.ts
+++ b/src/app/utils/reduce-day-forecasts.ts
@@ -15,6 +15,8 @@ export default function reduceDayForecasts(
       temp: current.main.temp,
       icon: current.weather[0].icon,
       wind: current.wind.speed,
+      windGust: current.wind.gust,
+      windDeg: current.wind.deg,
       description: current.weather[0].description,
       main: current.weather[0].main,
       rain: current.rain?.["3h"],


### PR DESCRIPTION
## Summary
- Tapping/hovering the wind speed now shows a popup with gust speed and wind direction (compass: N, NE, E, etc.)
- Added `gust` and `deg` to the wind Zod schemas (optional, not always present in API response)
- Threaded through `Forecast` type and `reduceDayForecasts`
- Follows the same `ui/Popup` pattern as weather icon and temperature popups

## Test plan
- [ ] Hover/tap wind — popup shows `Gust X km/h` and `From NW` (or whichever direction)
- [ ] On a forecast with no gust data — popup shows only direction (or nothing if both absent)
- [ ] SP: popup appears centered below wind element

🤖 Generated with [Claude Code](https://claude.com/claude-code)