### PR TITLE
Fix weather icon vertical alignment

### DIFF
--- a/src/app/ui/weather-icon.tsx
+++ b/src/app/ui/weather-icon.tsx
@@ -7,6 +7,7 @@ export default function WeatherIcon(props: { icon: string }) {
       height={50}
       src={`http://openweathermap.org/img/w/${props.icon}.png`}
       alt={`Weather icon ${props.icon}`}
+      style={{ objectFit: "contain", objectPosition: "center bottom" }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Cloud-only icons (03d, 04d) sit in the upper portion of their 50×50 bounding box with empty space below, making them appear higher than rain/sun icons
- Adding `object-position: center bottom` anchors all icons to the same visual baseline, so clouds no longer look like they're floating

## Test plan
- [ ] Compare a cloudy forecast card vs a rainy one — icons should sit at the same vertical position
- [ ] Verify on both SP and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)