### PR TITLE
Add wind gust/direction popup and fix SP layout issues

### DIFF
--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -27,6 +27,13 @@
   pointer-events: auto;
 }
 
+/* anchor to right edge on SP to avoid overflow */
+.container .popup.left {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+
 /* on larger screens, float to the side instead */
 @media (min-width: 600px) {
   .container .popup.right {

--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -1,5 +1,7 @@
 .container {
   position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .container .popup {

--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -2,6 +2,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }
 
 .container .popup {

--- a/src/app/ui/wind.tsx
+++ b/src/app/ui/wind.tsx
@@ -25,7 +25,7 @@ export default function Wind({ wind, gust, deg }: Props) {
 
   return (
     <Popup content={content} position="left">
-      <h5 style={{ transform: "translateY(5px)" }}>༄ {kmh} km/h</h5>
+      <h5>༄ {kmh} km/h</h5>
     </Popup>
   );
 }

--- a/src/app/ui/wind.tsx
+++ b/src/app/ui/wind.tsx
@@ -24,7 +24,7 @@ export default function Wind({ wind, gust, deg }: Props) {
   );
 
   return (
-    <Popup content={content}>
+    <Popup content={content} position="left">
       <h5 style={{ transform: "translateY(5px)" }}>༄ {kmh} km/h</h5>
     </Popup>
   );


### PR DESCRIPTION
## Summary
- Tapping/hovering wind speed shows a popup with gust speed and compass direction
- Fixed popup overflow on right-edge elements (Open Map button, wind) on SP — anchors to right edge instead of centering
- Fixed popup wrapper breaking card row layout — switched to `inline-flex`
- Fixed vertical centering of card elements on SP — removed `translateY` hack from wind, added `justify-content: center` to popup container

## Test plan
- [ ] SP: tap wind — popup appears without overflowing screen
- [ ] SP: tap Open Map button — popup appears without overflowing screen  
- [ ] SP: all card elements (time, icon, temp, wind) are vertically centered
- [ ] Desktop: wind popup floats to the left side correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)