### PR TITLE
Fix popup vertical alignment on real devices

### DIFF
--- a/src/app/ui/popup/popup.module.css
+++ b/src/app/ui/popup/popup.module.css
@@ -3,6 +3,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
 }
 
 .container .popup {


### PR DESCRIPTION
## Summary
- Added `align-self: center` to the popup container — prevents inline-flex elements from using baseline alignment which caused icon and wind to appear higher than temperature on real devices

## Test plan
- [ ] SP real device: time, icon, temperature and wind all sit on the same vertical center line

🤖 Generated with [Claude Code](https://claude.com/claude-code)