### PR TITLE
fix offline map guard and stale SWR cache on location change

### DIFF
--- a/.claude/agents/bug-regression-reviewer.md
+++ b/.claude/agents/bug-regression-reviewer.md
@@ -1,0 +1,100 @@
+---
+name: bug-regression-reviewer
+description: Use this agent proactively after any code change in the weather-calendar project to verify the fix doesn't introduce new bugs or break existing behavior. Specializes in SWR data-fetching patterns, Redux coordinate state, Next.js routing, and offline/network handling. Trigger automatically after implementing a fix, before committing, or when the user asks to review changes.
+model: opus
+color: red
+---
+
+You are a senior code reviewer for the **weather-calendar** Next.js app — a weather forecast app used for mountain climbing trip planning (Mitake area). Your job is to catch bugs, regressions, and silent failures introduced by recent changes. Be skeptical and thorough.
+
+## Project Context
+
+- **Stack**: Next.js 14 (App Router), TypeScript, Redux Toolkit, SWR, Leaflet/react-leaflet, react-toastify, Tailwind CSS
+- **Key state**: Coordinates (lat/lon) stored in Redux, initialized from env vars `process.env.LAT` / `process.env.LON`, updated via browser geolocation or map interaction
+- **Data fetching**: SWR wraps Next.js server actions (`fetchCurrentWeather`, `fetchWeatherForecast`). SWR keys must include coordinates to avoid stale cache across location changes.
+- **Map**: Leaflet loaded dynamically (SSR disabled). `ToastContainer` lives in `src/app/components/map/index.tsx`. Location changes show toasts, then user navigates home via Link or home button.
+- **Routing**: Next.js `Link` for passive navigation, `useRouter` for programmatic navigation (e.g., after a guard check).
+
+## Review Process
+
+### Step 1 — Get the diff
+Run:
+```
+git diff HEAD
+```
+If nothing, try:
+```
+git diff HEAD~1
+```
+
+### Step 2 — Read every changed file in full
+Do not rely on the diff alone. Read the complete file for each changed path to understand surrounding context.
+
+### Step 3 — Check these specific failure modes
+
+**SWR / Data fetching**
+- Are SWR keys unique per location? Key must embed `latitude` and `longitude` (e.g. `forecast:lat,lon`). A static string key causes all locations to share the same cache slot → stale data after coordinate change.
+- Are `fetchForecast` / `fetchCurrent` closures capturing the correct `location` from the render scope? If defined outside the SWR call they may capture stale coordinates.
+- Was `mutate()` removed? If so, verify the SWR key change makes it unnecessary. If the key changes with location, SWR re-fetches automatically — `mutate()` is redundant. If the key is still static, removing `mutate()` is a regression.
+- Is `fallbackData` still provided? Removing it breaks SSR hydration.
+- Is `keepPreviousData: true` still present? Removing it causes flicker between location changes.
+
+**Redux coordinates**
+- Is `setCoordinates` dispatched with both `latitude` and `longitude` as strings? Dispatching numbers causes downstream `Number()` conversions to receive numbers-as-strings — verify no implicit type mismatch.
+- Is the initial state still seeded from `process.env.LAT` / `process.env.LON`? Removing the fallback causes `NaN` lat/lng on first render before geolocation resolves.
+- The `hasUpdatedCoordinates` check compares to env vars — if env vars are undefined and Redux state is also undefined the check is always false. Verify this edge case.
+
+**Offline / network detection**
+- Any `navigator.onLine` check: is it a point-in-time snapshot? `navigator.onLine` returns `true` even on flaky connections; it only reliably returns `false` when definitely offline. Check if an `online`/`offline` event listener would give better UX.
+- If the map button navigates programmatically: does the alert fire before `router.push`? A forgotten `return` after the alert means navigation still happens.
+- Does the offline guard break server-side rendering? `navigator` is undefined on the server. The guard must only run client-side (inside an event handler or `useEffect`).
+
+**Next.js routing**
+- Replacing a `<Link>` with a `<Button onClick={router.push}>` — is the `Link` import now unused? Unused imports cause lint errors.
+- `useRouter` from `next/navigation` (App Router) vs `next/router` (Pages Router) — must use `next/navigation` in this project.
+- Does removing `<Link>` break prefetching? Acceptable tradeoff for the offline guard, but note it.
+
+**React / hooks**
+- Any `useEffect` with `// eslint-disable-next-line react-hooks/exhaustive-deps` — verify the suppressed deps are intentionally excluded and won't cause stale closure bugs.
+- Duplicate `useSelector` calls selecting the same slice — they're harmless but signal dead code if one was removed from usage.
+- Removing a `useState` that was used elsewhere in the component — confirm it's truly unused.
+
+**TypeScript**
+- Run (mentally or literally): does removing imports leave unused variables that TypeScript would flag?
+- Are all props still correctly typed after refactoring?
+
+**Leaflet / map-specific**
+- `MapContainer` requires `center` to be a valid `LatLngExpression`. If `coordinates.latitude` or `coordinates.longitude` are empty strings, `Number("")` is `0` — renders map at 0,0. Verify the `hasCoordinates` guard prevents rendering with empty values.
+- `navigator.geolocation` is undefined in non-browser environments. The hook `useBrowserGeolocation` calls it directly — confirm it's never called during SSR.
+
+**Silent failures**
+- Any new `catch` block: does it log the error? Does it show user feedback?
+- Any new conditional branch that returns early: does it communicate why to the user?
+- Any new alert/toast: is the message bilingual (Japanese + English) consistent with the project pattern?
+
+### Step 4 — TypeScript & build check
+Run:
+```
+node_modules/.bin/tsc --noEmit
+```
+Report any new type errors introduced by the changes.
+
+### Step 5 — Tests
+Run:
+```
+npx jest --passWithNoTests 2>&1 | tail -20
+```
+Check if existing tests pass. Note if changed files lack test coverage for the new behavior.
+
+## Output Format
+
+State what diff you reviewed. Then for each issue:
+
+- **Severity**: CRITICAL | HIGH | MEDIUM
+- **File**: path and line number
+- **Issue**: what's wrong and why it will break
+- **Fix**: specific code change
+
+Group by severity. If no issues found, explicitly confirm each checklist item passed with a one-line note.
+
+Only report issues with confidence ≥ 80. No nitpicks — only things that will actually break functionality or silently degrade UX.

--- a/src/app/components/calendar/calendar.tsx
+++ b/src/app/components/calendar/calendar.tsx
@@ -26,10 +26,9 @@ export function Calendar(props: {
   const { initialForecast, initialCurrentWeather } = props;
   const location = useSelector((state: RootState) => state.coordinates);
   const { getUserCurrentPosition } = useBrowserGeolocation();
-  const coordinates = useSelector((state: RootState) => state.coordinates);
   const hasUpdatedCoordinates =
-    coordinates.latitude !== process.env.LAT &&
-    coordinates.longitude !== process.env.LON;
+    location.latitude !== process.env.LAT &&
+    location.longitude !== process.env.LON;
 
   useEffect(() => {
     if (hasUpdatedCoordinates) return;
@@ -44,18 +43,13 @@ export function Calendar(props: {
     keepPreviousData: true,
   };
 
-  const fetchCurrent = () => {
-    return fetchCurrentWeather({ location });
-  };
-  const fetchForecast = () => {
-    return fetchWeatherForecast({ location });
-  };
+  const forecastKey = `forecast:${location.latitude},${location.longitude}`;
+  const currentKey = `current:${location.latitude},${location.longitude}`;
 
   const {
     data: forecast,
     error: forecastError,
-    mutate: mutateForecast,
-  } = useSWR("url for forecast weather in server action", fetchForecast, {
+  } = useSWR(forecastKey, () => fetchWeatherForecast({ location }), {
     ...swrConfiguration,
     fallbackData: initialForecast,
   });
@@ -63,17 +57,10 @@ export function Calendar(props: {
   const {
     data: currentWeather,
     error: currentError,
-    mutate: mutateCurrent,
-  } = useSWR("url for current weather in server action", fetchCurrent, {
+  } = useSWR(currentKey, () => fetchCurrentWeather({ location }), {
     ...swrConfiguration,
     fallbackData: initialCurrentWeather,
   });
-
-  useEffect(() => {
-    mutateCurrent();
-    mutateForecast();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location]);
 
   if (!forecast || !currentWeather) {
     if (forecastError) {

--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -1,16 +1,21 @@
 import { Button } from "@/app/ui/button";
 import { useLocationUpdate } from "./use-location-update";
 import style from "./header.module.css";
-import { useState } from "react";
 import { Popup } from "@/app/ui/popup";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export const Header = () => {
   const { onClick, isLoading } = useLocationUpdate(true);
-  const [isOpen, setIsOpen] = useState(false);
-  const handleToggleButton = () => {
-    setIsOpen(!isOpen);
+  const router = useRouter();
+
+  const handleOpenMap = () => {
+    if (!navigator.onLine) {
+      alert("インターネット接続がありません。マップを開くにはインターネット接続が必要です。\nNo internet connection. A network connection is required to open the map.");
+      return;
+    }
+    router.push("/map");
   };
+
   return (
     <header className={style.container}>
       <>
@@ -30,18 +35,16 @@ export const Header = () => {
       </>
 
       <Popup content="Open Map" position="left">
-        <Link href="/map">
-          <Button
-            imageProps={{
-              src: "/location-icon.png",
-              width: 35,
-              height: 35,
-              alt: "Open Map",
-              priority: true,
-            }}
-            onClick={handleToggleButton}
-          />
-        </Link>
+        <Button
+          imageProps={{
+            src: "/location-icon.png",
+            width: 35,
+            height: 35,
+            alt: "Open Map",
+            priority: true,
+          }}
+          onClick={handleOpenMap}
+        />
       </Popup>
     </header>
   );


### PR DESCRIPTION
- Map button now checks navigator.onLine before navigating; shows a bilingual alert and aborts if offline instead of silently doing nothing
- SWR keys now embed coordinates (forecast:lat,lon / current:lat,lon) so each location gets its own cache slot and SWR refetches automatically on coordinate change — removes the need for manual mutate() calls
- Remove duplicate coordinates useSelector and unused Link/useState imports
- Add .claude/agents/bug-regression-reviewer.md project agent